### PR TITLE
Add energy source for region function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     # it will be auto-pinned to the latest release version by the pre-release workflow
     #
     "bluesky",
-    "dls-dodal@git+https://github.com/DiamondLightSource/dodal.git@move_region_setup_logic_to_region_detector", #remove when merged.
+    "dls-dodal",
     "ophyd-async >= 0.10.0a2",
     "scanspec",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
     # it will be auto-pinned to the latest release version by the pre-release workflow
     #
     "bluesky",
-    "dls-dodal",
+    "dls-dodal@git+https://github.com/DiamondLightSource/dodal.git@move_region_setup_logic_to_region_detector", #remove when merged.
     "ophyd-async >= 0.10.0a2",
     "scanspec",
 ]

--- a/src/sm_bluesky/common/electron_analyser/energy_source.py
+++ b/src/sm_bluesky/common/electron_analyser/energy_source.py
@@ -19,5 +19,5 @@ def get_energy_source_for_region(
         raise KeyError(
             f"Region {region.name} selected excitation energy"
             + f"{region.excitation_energy_source}. This isn't a "
-            + f"valid source. Valid sources are {energy_sources.keys()}."
+            + f"valid source. Valid sources are {list(energy_sources.keys())}."
         ) from e

--- a/src/sm_bluesky/common/electron_analyser/energy_source.py
+++ b/src/sm_bluesky/common/electron_analyser/energy_source.py
@@ -1,0 +1,23 @@
+from dodal.devices.electron_analyser.abstract import (
+    AbstractBaseRegion,
+)
+from ophyd_async.core import DeviceVector
+from ophyd_async.epics.motor import Motor
+
+# This is needed as a workaround until this is fixed
+# https://github.com/bluesky/ophyd-async/issues/903
+key_to_index = {"source1": 0, "source2": 1}
+
+
+def get_energy_source_for_region(
+    region: AbstractBaseRegion, energy_sources: DeviceVector[Motor]
+) -> Motor:
+    try:
+        source_alias: str = region.excitation_energy_source
+        return energy_sources[key_to_index[source_alias]]
+    except KeyError as e:
+        raise KeyError(
+            f"Region {region.name} selected excitation energy"
+            + f"{region.excitation_energy_source}. This isn't a "
+            + f"valid source. Valid sources are {energy_sources.keys()}."
+        ) from e

--- a/tests/common/electron_analyser/test_energy_source.py
+++ b/tests/common/electron_analyser/test_energy_source.py
@@ -1,0 +1,53 @@
+import pytest
+from dodal.devices.electron_analyser.vgscienta import VGScientaRegion
+from ophyd_async.core import DeviceVector, init_devices
+from ophyd_async.epics.motor import Motor
+
+from sm_bluesky.common.electron_analyser.energy_source import (
+    get_energy_source_for_region,
+)
+
+
+@pytest.fixture
+async def dcmenergy() -> Motor:
+    async with init_devices(mock=True, connect=True):
+        dcmenergy = Motor("TEST-DCM:")
+    return dcmenergy
+
+
+@pytest.fixture
+async def pgmenergy() -> Motor:
+    async with init_devices(mock=True, connect=True):
+        pgmenergy = Motor("TEST-PGM:")
+    return pgmenergy
+
+
+@pytest.fixture
+async def energy_sources(pgmenergy: Motor, dcmenergy: Motor) -> DeviceVector[Motor]:
+    async with init_devices(mock=True, connect=True):
+        energy_source = DeviceVector({0: dcmenergy, 1: pgmenergy})
+    return energy_source
+
+
+def test_energy_source_for_region_has_region_select_source1_is_valid(
+    energy_sources, dcmenergy
+) -> None:
+    region = VGScientaRegion(excitation_energy_source="source1")
+    energy_source = get_energy_source_for_region(region, energy_sources)
+    assert energy_source == dcmenergy
+
+
+def test_energy_source_for_region_has_region_select_source2_is_valid(
+    energy_sources, pgmenergy
+) -> None:
+    region = VGScientaRegion(excitation_energy_source="source2")
+    energy_source = get_energy_source_for_region(region, energy_sources)
+    assert energy_source == pgmenergy
+
+
+def test_energy_source_for_region_has_region_select_invalid_source_is_invalid(
+    energy_sources,
+) -> None:
+    region = VGScientaRegion(excitation_energy_source="invalid_source")
+    with pytest.raises(KeyError):
+        get_energy_source_for_region(region, energy_sources)


### PR DESCRIPTION
Add way to get the corresponding energy source that is requested by a region. https://github.com/DiamondLightSource/sm-bluesky/issues/36

### Instructions to reviewer on how to test:
1. Check new tests are valid
2. Check current tests still pass
3. Check file structure makes sense

### Checks for reviewer
- [ ] Would the PR title make sense to a user on a set of release notes
