### PR TITLE
removed python 3.13 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # The devcontainer should use the developer target and run as root with podman
 # or docker with user namespaces.
-ARG PYTHON_VERSION=3.11
+ARG PYTHON_VERSION=3.12
 FROM python:${PYTHON_VERSION} AS developer
 
 # Add any system dependencies for the developer/build environment here

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
 ]
 description = "Bluesky code for Diamond's surface and magnetic materials beamline."
 dependencies = [


### PR DESCRIPTION
Fixes #40 

### Instructions to reviewer on how to test:
1. Ensure test is now passing and 3.13 support is dropped. 
2. 
### Checks for reviewer
- [ ] Would the PR title make sense to a user on a set of release notes
